### PR TITLE
Sync before snapshot creation

### DIFF
--- a/snapshot.sh
+++ b/snapshot.sh
@@ -6,6 +6,8 @@ SNAPSHOT_NAME=''
 
 DATE=`date '+%Y%m%d-%H%M%S'`
 
+sync
+
 curl -X POST \
   "https://api.digitalocean.com/v2/volumes/$VOLUME_ID/snapshots" \
   -H "authorization: Bearer $DIGITALOCEAN_TOKEN" \


### PR DESCRIPTION
Instruct the OS to flush all buffers to disk before triggering the snapshot. A
proper FS quiesce would be even better but there's no generic way to do that,
settle for a sync here.